### PR TITLE
Remove author from setup.py for privacy reason

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ from setuptools import setup, find_packages
 setup(
     name = "destream",
     version = "5.0.1",
-    author = "Cecile Tonglet",
-    author_email = "cecile.tonglet@cecton.com",
     description = ("A simple module to decompress streams compressed multiple "
                    "times"),
     long_description=Path("README.md").read_text(),


### PR DESCRIPTION
> You are the original author. We can put Javier and me into the maintainer field though. Actually I have very little experience with what should be maintained which way on PyPI.

No no you don't get it. I really WANT to delete this field. It doesn't mean I'm not the original author or anything :sweat_smile: it just means I don't want this information with my email address appearing there.

Feel free to add the `maintainer` and `maintainer_email` if you want but I don't recommend it. People who needs support should always come to this repository and open an issue. Not contact people directly.

AFAIU The only constrain of the setup.py is that if you specify `author`, you must specify a valid `author_email`. And I suppose it's the same for `maintainer` and `maintainer_email`.

My "authorship" and my contributions in general are in the history of the repository and on GitHub so I am really happy and proud with that :smiley: 

Doc: https://packaging.python.org/specifications/core-metadata/#author